### PR TITLE
Fixed the error "restricted hash"

### DIFF
--- a/lib/Ukigumo/Agent/Dispatcher.pm
+++ b/lib/Ukigumo/Agent/Dispatcher.pm
@@ -29,7 +29,7 @@ get '/' => sub {
 my $rule = Data::Validator->new(
     repository => { isa => 'Str' },
     branch     => { isa => 'Str' },
-)->with(qw/NoThrow NoRestricted/);
+)->with('NoThrow');
 post '/api/v0/enqueue' => sub {
     my $c = shift;
 
@@ -42,7 +42,7 @@ post '/api/v0/enqueue' => sub {
         return $res;
     }
 
-    $c->manager->register_job($args);
+    $c->manager->register_job(+{%$args});
 
     return $c->render_json(+{});
 };

--- a/lib/Ukigumo/Agent/Dispatcher.pm
+++ b/lib/Ukigumo/Agent/Dispatcher.pm
@@ -29,7 +29,7 @@ get '/' => sub {
 my $rule = Data::Validator->new(
     repository => { isa => 'Str' },
     branch     => { isa => 'Str' },
-)->with('NoThrow');
+)->with(qw/NoThrow NoRestricted/);
 post '/api/v0/enqueue' => sub {
     my $c = shift;
 

--- a/lib/Ukigumo/Agent/Manager.pm
+++ b/lib/Ukigumo/Agent/Manager.pm
@@ -124,9 +124,9 @@ sub run_job {
         vc          => $vc,
         executor    => Ukigumo::Client::Executor::Perl->new(),
         server_url  => $self->server_url,
-        compare_url => $args->{compare_url},
-        repository_owner => $args->{repository_owner},
-        repository_name  => $args->{repository_name},
+        compare_url => $args->{compare_url} || '',
+        repository_owner => $args->{repository_owner} || '',
+        repository_name  => $args->{repository_name} || '',
     );
 
     my $client_log_filename = $client->logfh->filename;


### PR DESCRIPTION
/api/v0/enqueue の$argsがrestricted hashのため、Ukigumo::Client.newに渡す値の参照時にエラーになるので`NoRestricted`を有効にしました。

これに伴い、Ukigumo::Client.newに値としてundefが渡されることがあるため、空文字を初期値としています。
